### PR TITLE
Allow customization of slash command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Slack Channel Set Up
 
 1. In your channel settings, select "Customize Slack." Choose "Configure Apps" --> "Custom Integrations"  
 2. Add a "Slash Commands" integration
-3. In the "command" section, enter "/parsely" (without quotes)
+3. In the "command" section, enter the `slash_command` value from the config (the default is `parsely`).
 4. In the "URL" field, enter the URL your slackbot will be running on, created in the Server Set Up step. Make sure to specify the port in the style of http://EXAMPLE.com:6000. (The default port is 6000 for the slackbot)
 5. The rest of the fields can be left as their defaults. You can also upload the `Parse.ly logo <http://www.parsely.com/static/img/parsely-green-leaf-m.png>`_. 
 

--- a/parsely_slackbot/app.py
+++ b/parsely_slackbot/app.py
@@ -27,7 +27,7 @@ def init(config_args):
 
 
 
-    @slack.command('parsely', token=config['slack_token'], team_id=config['team_id'], methods=['POST'])
+    @slack.command(config['slash_command'], token=config['slack_token'], team_id=config['team_id'], methods=['POST'])
     def parsely(text=None, channel=None, **kwargs):
         parsed_commands = parsely_bot.parse(text)
         if not parsed_commands:

--- a/parsely_slackbot/slackbot.py
+++ b/parsely_slackbot/slackbot.py
@@ -32,6 +32,9 @@ team_id: T12345
 # Slack slash commands integration token
 slack_token: abcdef12345
 
+# Slash command name
+slash_command: parsely
+
 # posts to return for each query
 limit: 5
 
@@ -213,24 +216,24 @@ class SlackBot(object):
     def help(self):
         # returns help commands
         return '''
-Command syntax: /parsely meta, time
+Command syntax: /{0} meta, time
 returns top metas for past minutes / hours
 
 possible values for meta: posts, authors, sections, tags, referrers
 possible values for time: a number followed by m for minutes or h for hours (ex. 30m, 12h). Max time value 24h
 
-/parsely posts, 10m
+/{0} posts, 10m
 Will return top posts for last 10 minutes
 
-/parsely sections, 1h
+/{0} sections, 1h
 Will return top sections for last hour
 
-/parsely tags, today
+/{0} tags, today
 Will return top tags for today
 
 See all example commands: http://bit.ly/parsely_slack
 
-'''
+'''.format(self.config['slash_command'])
 
 
 


### PR DESCRIPTION
We have what might be a unique situation.  We have one Slack instance for the company but we actually have two different domains in Parsely.  Upon installing the slackbot I discovered that this wasn't so easy to do.

This PR allows for the customization of the `slash_command` so that you can have multiple commands in a single Slack Team.  In our case one per domain.
